### PR TITLE
Fix error is not assigned correctly.

### DIFF
--- a/MTLManagedObjectAdapter/MTLManagedObjectAdapter.m
+++ b/MTLManagedObjectAdapter/MTLManagedObjectAdapter.m
@@ -452,7 +452,7 @@ static SEL MTLSelectorWithKeyPattern(NSString *key, const char *suffix) {
 					id<MTLTransformerErrorHandling> errorHandlingTransformer = (id)transformer;
 
 					BOOL success = YES;
-					transformedValue = [errorHandlingTransformer reverseTransformedValue:value success:&success error:error];
+					transformedValue = [errorHandlingTransformer reverseTransformedValue:value success:&success error:&tmpError];
 
 					if (!success) return NO;
 				} else {


### PR DESCRIPTION
when error is used inside a block of *-enumerateKeysAndObjectsUsingBlock:*. It setups an autorelease pool, by the time it returns, any out error will be deallocaed. we need to use __block, as in code *tmpError

I assume put error in enumerateKeysAndObjectsUsingBlock is equal to code below. 
```
- (void)produceError3:(NSError **)error {
    void (^errorProduceBlock)() = ^{
        @autoreleasepool {
            *error = [NSError errorWithDomain:@"AWESOME ERROR" code:0 userInfo:nil];
        }
    };
    
    errorProduceBlock();
}
```

```
- (void)produceError5:(NSError **)error {
    [@{@"DD":@"YY"} enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
        *error = [NSError errorWithDomain:@"AWESOME ERROR" code:0 userInfo:nil];
    }];
}
```

Both code will crash. But I don't know why MTLManagedObjectAdapter won't crash, it will just silently ignore the error. 