### PR TITLE
Eliminate the non-null comparison for the attributes.type char array as it always return true.

### DIFF
--- a/MTLManagedObjectAdapter/MTLManagedObjectAdapter.m
+++ b/MTLManagedObjectAdapter/MTLManagedObjectAdapter.m
@@ -751,7 +751,7 @@ static SEL MTLSelectorWithKeyPattern(NSString *key, const char *suffix) {
 			transformer = [self.class transformerForModelPropertiesOfClass:attributes->objectClass];
 		}
 
-		if (transformer == nil && attributes->type != NULL) {
+		if (transformer == nil) {
 			transformer = [self.class transformerForModelPropertiesOfObjCType:attributes->type];
 		}
 


### PR DESCRIPTION
Per discussions with @jspahrsummers

Making a pull-req here, since the non-null comparison [doesn't live upstream in libextobjc](https://github.com/jspahrsummers/libextobjc/pull/115). If we just pull in this req (or the other one that [also updates Quick and Nimble](https://github.com/Mantle/MTLManagedObjectAdapter/pull/21) if you prefer), everything should be all squared away -- no more build errors on Xcode 6.3+.
